### PR TITLE
Requirements file parsed in setup.py for install_requires

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib==2.1.0
+pandas==0.13.1
+statsmodels==0.8.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 from setuptools import setup, find_packages  # Always prefer setuptools over distutils
 from codecs import open  # To use a consistent encoding
-from os import path
+import os
+
+
+REPO_DIR = os.path.dirname(os.path.realpath(__file__))
+
 
 # Get the long description from the relevant file
 # with open(path.join(here, 'DESCRIPTION.rst'), encoding='utf-8') as f:
@@ -8,6 +12,13 @@ from os import path
 def readme():
     with open('README.rst') as f:
         return f.read()
+
+
+def get_requirements():
+    """Parses and returns installation requirements."""
+    path = os.path.join(REPO_DIR, "requirements.txt")
+    return [line.strip() for line in open(path).readlines()
+            if not line.startswith("#")]
 
 setup(
     name='FATS',
@@ -70,15 +81,13 @@ setup(
 
     include_package_data=True,
 
-    zip_safe=False
+    zip_safe=False,
 
     # List run-time dependencies here.  These will be installed by pip when your
     # project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/technical.html#install-requires-vs-requirements-files
-    
-    # isa
-    # install_requires=['peppercorn'],
+    install_requires=get_requirements()
 
     # List additional groups of dependencies here (e.g. development dependencies).
     # You can install these using the following syntax, for example:


### PR DESCRIPTION
I installed FATS in a fresh python2 venv without any other packages. However, I was not able to import FATS in the python console because of missing dependencies. Please consider my change. 