### PR TITLE
Changed optimization method to Powell for calculate_CAR

### DIFF
--- a/FATS/FeatureFunctionLib.py
+++ b/FATS/FeatureFunctionLib.py
@@ -967,7 +967,7 @@ class CAR_sigma(Base):
         # method='nelder-mead',bounds = bnds)
 
         res = minimize(self.CAR_Lik, x0, args=(time, data, error),
-                       method='nelder-mead', bounds=bnds)
+                       method='powell', bounds=bnds)
         # options={'disp': True}
         sigma = res.x[0]
         global tau


### PR DESCRIPTION
I have found that the nelder-mead optimization does not behave well to find the CAR parameters. For a significant number of light curves, it gives a CAR_sigma very close to zero that is not realistic. The issue seems to be fixed if you use the Powell optimization method in scipy instead. This pull request only changes the optimization method in FeatureFunctionLib.py.